### PR TITLE
修改reqwest依赖方式，确保开启rust-tls feature的时候，不会依赖openssl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ md5 = "0.7.0"
 mime_guess = "2.0.5"
 quick-xml = { version = "0.37.2"}
 regex = "1.11.1"
-reqwest = {version = "0.12.12", features = ["stream"]}
+reqwest = {version = "0.12.12", default-features = false, features = ["stream"]}
 serde = { version = "1.0.217", features = ["derive"]}
 serde_json = "1.0.138"
 sha2 = "0.10.8"
@@ -46,7 +46,7 @@ uuid = { version = "1.4.1", features = ["v4"] }
 
 [features]
 # Default features, using async request to call Aliyun OSS API
-default=["async"]
+default=["async", "native-tls"]
 async=[]
 
 # Support synchronous request to call Aliyun OSS API
@@ -54,6 +54,7 @@ blocking = ["reqwest/blocking"]
 
 # Enable `rustls-tls` feature on `reqwest` crate
 rust-tls = ["reqwest/rustls-tls"]
+native-tls = ["reqwest/native-tls"]
 
 # Enable serialization/deserialization on data types. Usful if you are using this crate for backend API
 serde-support = []


### PR DESCRIPTION
按照之前的引入`reqwest`的方式，不论是否开启`rust-tls`，`reqwest`都会引入`native-tls`依赖，导致最终构建出来的可执行程序会依赖openssl，不便于分发。